### PR TITLE
8290049: Committers should be able to review for Shenandoah 8u

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -21,7 +21,7 @@ files=.*\.cpp|.*\.hpp|.*\.c|.*\.h|.*\.java
 message=Merge.*
 
 [checks "reviewers"]
-reviewers=1
+committers=1
 ignore=duke
 
 [checks "committer"]


### PR DESCRIPTION
According to @rkennke, "it is sufficient to be a Committer in order to officially review Shenandoah PRs"

We should change the `jcheck` configuration to reflect this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290049](https://bugs.openjdk.org/browse/JDK-8290049): Committers should be able to review for Shenandoah 8u


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk8u pull/4/head:pull/4` \
`$ git checkout pull/4`

Update a local copy of the PR: \
`$ git checkout pull/4` \
`$ git pull https://git.openjdk.org/shenandoah-jdk8u pull/4/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4`

View PR using the GUI difftool: \
`$ git pr show -t 4`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk8u/pull/4.diff">https://git.openjdk.org/shenandoah-jdk8u/pull/4.diff</a>

</details>
