### PR TITLE
8260632: Build failures after JDK-8253353

### DIFF
--- a/hotspot/src/share/vm/gc_implementation/shenandoah/c2/shenandoahSupport.cpp
+++ b/hotspot/src/share/vm/gc_implementation/shenandoah/c2/shenandoahSupport.cpp
@@ -2189,7 +2189,7 @@ void MemoryGraphFixer::collect_memory_nodes() {
   uint last = _phase->C->unique();
 
 #ifdef ASSERT
-  uint8_t max_depth = 0;
+  uint16_t max_depth = 0;
   for (LoopTreeIterator iter(_phase->ltree_root()); !iter.done(); iter.next()) {
     IdealLoopTree* lpt = iter.current();
     max_depth = MAX2(max_depth, lpt->_nest);


### PR DESCRIPTION
Necessary backport to fix the build now JDK-8253353 has been backported to 8u in 8u332-b01

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8260632](https://bugs.openjdk.org/browse/JDK-8260632): Build failures after JDK-8253353


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-jdk8u pull/6/head:pull/6` \
`$ git checkout pull/6`

Update a local copy of the PR: \
`$ git checkout pull/6` \
`$ git pull https://git.openjdk.org/shenandoah-jdk8u pull/6/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6`

View PR using the GUI difftool: \
`$ git pr show -t 6`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-jdk8u/pull/6.diff">https://git.openjdk.org/shenandoah-jdk8u/pull/6.diff</a>

</details>
