### PR TITLE
Merge jdk8u:master

### DIFF
--- a/hotspot/src/share/vm/opto/matcher.cpp
+++ b/hotspot/src/share/vm/opto/matcher.cpp
@@ -2230,6 +2230,7 @@ void Matcher::find_shared( Node *n ) {
                 // AtomicAdd is not an addressing expression.
                 // Cheap to find it by looking for screwy base.
                 !adr->in(AddPNode::Base)->is_top() &&
+                X86_ONLY(LP64_ONLY( off->get_long() == (int) (off->get_long()) && )) // immL32
                 // Are there other uses besides address expressions?
                 !is_visited(adr) ) {
               address_visited.set(adr->_idx); // Flag as address_visited

--- a/hotspot/test/compiler/c2/TestMatcherLargeOffset.java
+++ b/hotspot/test/compiler/c2/TestMatcherLargeOffset.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8202952
+ * @summary C2: Unexpected dead nodes after matching
+ *
+ * @run main/othervm -XX:-TieredCompilation -Xcomp -XX:CompileOnly=::test
+ *      compiler.c2.TestMatcherLargeOffset
+ */
+package compiler.c2;
+
+public class TestMatcherLargeOffset {
+
+    public static int s = 0;
+    public static final int N = 400;
+    public static int a[] = new int[N];
+
+    public static void test() {
+        int x = -57785;
+
+        for (int i = 0; i < N; i++) {
+            a[(x >>> 1) % N] &= (--x);
+
+            for (int j = 4; j > 1; j -= 3) {
+                switch ((j % 9) + 119) {
+                    case 122:
+                        s += i;
+                        break;
+                    case 123:
+                        s += i;
+                        break;
+                    default:
+                }
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 16000; i++) {
+            test();
+        }
+
+        System.out.println("s = " + s);
+   }
+}

--- a/jdk/src/share/demo/nio/zipfs/src/com/sun/nio/zipfs/ZipFileSystem.java
+++ b/jdk/src/share/demo/nio/zipfs/src/com/sun/nio/zipfs/ZipFileSystem.java
@@ -2461,16 +2461,17 @@ public class ZipFileSystem extends FileSystem {
                             locPos += locSZ;
                              continue;
                         }
+                        int end = locPos + locSZ - 4;
                         int flag = CH(buf, locPos++);
-                        if ((flag & 0x1) != 0) {
+                        if ((flag & 0x1) != 0 && locPos <= end) {
                             mtime = unixToJavaTime(LG(buf, locPos));
                             locPos += 4;
                         }
-                        if ((flag & 0x2) != 0) {
+                        if ((flag & 0x2) != 0 && locPos <= end) {
                             atime = unixToJavaTime(LG(buf, locPos));
                             locPos += 4;
                         }
-                        if ((flag & 0x4) != 0) {
+                        if ((flag & 0x4) != 0 && locPos <= end) {
                             ctime = unixToJavaTime(LG(buf, locPos));
                             locPos += 4;
                         }


### PR DESCRIPTION
Merge jdk8u392-b04

GHA builds will not work until [JDK-8293107](https://bugs.openjdk.org/browse/JDK-8293107) is merged in 8u462-b01